### PR TITLE
Added the file separator / when the machine is unix.

### DIFF
--- a/NPMK/Dependent Functions/getSettingFileFullPath.m
+++ b/NPMK/Dependent Functions/getSettingFileFullPath.m
@@ -6,6 +6,8 @@ if ~isempty(settingFileFullPath)
     settingFilePath = fileparts(settingFileFullPath);
     if ismac
         settingFileFullPath = [settingFilePath '/' functionName '.ini'];
+    elseif isunix
+        settingFileFullPath = [settingFilePath '/' functionName '.ini'];
     else
         settingFileFullPath = [settingFilePath '\' functionName '.ini'];
     end


### PR DESCRIPTION
When I tried to use openNSx on CentOS, one of the Unix-like systems, file name I selected by GUI interface was confused with "/" and "\". So, I fixed it by simply mimicking the case of Mac.