### PR TITLE
Removed floor() from MetaTags.DataDurationSec

### DIFF
--- a/NPMK/Other tools/samplealign.m
+++ b/NPMK/Other tools/samplealign.m
@@ -208,14 +208,14 @@ for j=1:nargin
         for jj = 1:length(tempts{j})
             Data{j}.MetaTags.Timestamp(jj) = tempts{j}{jj}(1);
             Data{j}.MetaTags.DataPoints(jj) = length(Data{j}.Data{jj});
-            Data{j}.MetaTags.DataDurationSec(jj) = floor(length(Data{j}.Data{jj})/freq(j));
-            Data{j}.MetaTags.DataPointsSec(jj) = floor(length(Data{j}.Data{jj})/freq(j));
+            Data{j}.MetaTags.DataDurationSec(jj) = length(Data{j}.Data{jj})/freq(j);
+            Data{j}.MetaTags.DataPointsSec(jj) = length(Data{j}.Data{jj})/freq(j);
         end
     else
         Data{j}.MetaTags.Timestamp = tempts{j}(1);
         Data{j}.MetaTags.DataPoints = length(Data{j}.Data);
-        Data{j}.MetaTags.DataDurationSec = floor(length(Data{j}.Data)/freq(j));
-        Data{j}.MetaTags.DataPointsSec = floor(length(Data{j}.Data)/freq(j));
+        Data{j}.MetaTags.DataDurationSec = length(Data{j}.Data)/freq(j);
+        Data{j}.MetaTags.DataPointsSec = length(Data{j}.Data)/freq(j);
     end
     
     


### PR DESCRIPTION
Running test protocol caught this. I'm seeing that outputs from `samplealign` are flooring the file duration readout when they shouldn't be floored. It should be a decimal value assuming `mod(ndatapoints, samplingfreq) ~= 0`

Debatable if we need to bump up a version number. This amounts to a very minor fix.