### PR TITLE
Additional corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # Executables
 *.exe
+*.ns6


### PR DESCRIPTION
Address error with 'noread' input; change ElectrodeID to ChannelID in NSx.MetaTags.ElectrodeInfo; fix logic and improve commenting for data point selection; improve documentation for duration, channel, and electrode input.