### PR TITLE
Daqs 845 npmk looks for incorrect sif file with multiple instruments

### DIFF
--- a/NPMK/openNEV.m
+++ b/NPMK/openNEV.m
@@ -454,7 +454,7 @@ if or(strcmpi(NEV.MetaTags.FileTypeID, 'NEURALEV'), strcmpi(NEV.MetaTags.FileTyp
         NEV.MetaTags.Subject      = METATAGS{3}(5:end-5);
         NEV.MetaTags.Experimenter = [METATAGS{5}(8:end-8) ' ' METATAGS{6}(7:end-7)];
     else
-        warning(['No .sif file found corresponding to ' fullFilePath...
+        warning(['No .sif file found corresponding to ' fileFullPath...
             '. Subject and Experimenter data skipped in MetaTags']);
     end
 end


### PR DESCRIPTION
Fixes issue where subject and experimenter info can't be parsed into NEV.MetaTags because of bad filename reading arguments for a recording that generates a .sif file. Bug occurs when there are several nodes on the network in Gemini configurations. Added warning for cases where Experimenter and Subject can't be ID'd due to missing .sif.