### PR TITLE
Toren's suggestion

### DIFF
--- a/NPMK/openNEV.m
+++ b/NPMK/openNEV.m
@@ -733,7 +733,7 @@ if strcmpi(Flags.ReadData, 'read')
             else
                 diffFactor = 1; % sample count
             end
-            tempTimeStampStarted = NEV.Data.Comments.TimeStamp-uint64(diffTimeStampStarted)*diffFactor;
+            tempTimeStampStarted = uint64(NEV.Data.Comments.TimeStamp)-uint64(diffTimeStampStarted)*diffFactor;
             NEV.Data.Comments.TimeStampStarted = tempTimeStampStarted(orderOfTS); clear diffTimeStampStarted tempTimeStampStarted;
             NEV.Data.Comments.Color = dec2hex(typecast(tempPayload(:),'uint32')); clear tempPayload
             


### PR DESCRIPTION
Bug found with older file specs with NEV comments. Typecast error between 32-bit and the now-forced 64-bit timestamp outputs. This fixes that issue.

Note: PR is towards `development` branch. This won't hit a release until the product team requests it